### PR TITLE
Add POSIX configuration migration and legacy-format warnings

### DIFF
--- a/src/GitVersion.App.Tests/ArgumentParserTests.cs
+++ b/src/GitVersion.App.Tests/ArgumentParserTests.cs
@@ -106,6 +106,27 @@ public class ArgumentParserTests : TestBase
     }
 
     [Test]
+    public void ConfigMigrateParsesItsInputAndOutputOptions()
+    {
+        var arguments = this.argumentParser.ParseArguments(
+            "config migrate --config GitVersion.yml --output GitVersion.v7.yml --force");
+
+        arguments.IsConfigurationMigration.ShouldBeTrue();
+        arguments.MigrationInputFile.ShouldBe("GitVersion.yml");
+        arguments.MigrationOutputFile.ShouldBe("GitVersion.v7.yml");
+        arguments.MigrationForce.ShouldBeTrue();
+    }
+
+    [Test]
+    public void ConfigMigrateRejectsOutputAndInPlaceTogether()
+    {
+        var exception = Should.Throw<WarningException>(() =>
+            this.argumentParser.ParseArguments("config migrate --output GitVersion.v7.yml --in-place"));
+
+        exception.Message.ShouldBe("Cannot use --output together with --in-place.");
+    }
+
+    [Test]
     public void EmptyMeansUseCurrentDirectory()
     {
         var arguments = this.argumentParser.ParseArguments("");

--- a/src/GitVersion.App.Tests/ArgumentParserTests.cs
+++ b/src/GitVersion.App.Tests/ArgumentParserTests.cs
@@ -127,6 +127,15 @@ public class ArgumentParserTests : TestBase
     }
 
     [Test]
+    public void TargetPathAllowsDirectoryNamedConfig()
+    {
+        var arguments = this.argumentParser.ParseArguments("--target-path config");
+
+        arguments.TargetPath.ShouldBe("config");
+        arguments.IsConfigurationMigration.ShouldBeFalse();
+    }
+
+    [Test]
     public void EmptyMeansUseCurrentDirectory()
     {
         var arguments = this.argumentParser.ParseArguments("");

--- a/src/GitVersion.App.Tests/ConfigurationMigrationExecutorTests.cs
+++ b/src/GitVersion.App.Tests/ConfigurationMigrationExecutorTests.cs
@@ -1,0 +1,44 @@
+using System.IO.Abstractions;
+using GitVersion.Configuration;
+using GitVersion.Tests;
+
+namespace GitVersion.App.Tests;
+
+[TestFixture]
+public class ConfigurationMigrationExecutorTests
+{
+    [Test]
+    public void InPlaceMigrationWarnsThatCommentsCannotBePreserved()
+    {
+        var directory = Directory.CreateTempSubdirectory();
+        try
+        {
+            var inputFile = Path.Combine(directory.FullName, "legacy.yml");
+            File.WriteAllText(inputFile, "next-version: 2.0.0");
+            var logMessages = new List<string>();
+            var executor = new ConfigurationMigrationExecutor(
+                new FileSystem(),
+                new TestConsoleAdapter(new StringBuilder()),
+                new TestLogger<ConfigurationMigrationExecutor>(logMessages.Add),
+                Substitute.For<IConfigurationFileLocator>(),
+                new MigrationService());
+            var options = new GitVersionOptions { WorkingDirectory = directory.FullName };
+            options.ConfigurationMigrationInfo.IsMigration = true;
+            options.ConfigurationMigrationInfo.InputFile = inputFile;
+            options.ConfigurationMigrationInfo.InPlace = true;
+
+            executor.Execute(options).ShouldBe(0);
+
+            logMessages.ShouldContain(message => message.Contains("Comments cannot be preserved during migration.", StringComparison.Ordinal));
+        }
+        finally
+        {
+            directory.Delete(recursive: true);
+        }
+    }
+
+    private sealed class MigrationService : IConfigurationMigrationService
+    {
+        public string Migrate(string input) => "calculation: {}\noutput: {}\n";
+    }
+}

--- a/src/GitVersion.App.Tests/ConfigurationVersionIntegrationTests.cs
+++ b/src/GitVersion.App.Tests/ConfigurationVersionIntegrationTests.cs
@@ -62,6 +62,30 @@ public class ConfigurationVersionIntegrationTests
     }
 
     [Test]
+    public async Task ConfigMigrateLeavesNoTemporaryFileAfterWritingOutput()
+    {
+        var directory = Directory.CreateTempSubdirectory();
+        try
+        {
+            var configurationPath = Path.Combine(directory.FullName, ConfigurationFileLocator.DefaultFileName);
+            await File.WriteAllTextAsync(configurationPath, "next-version: 2.0.0");
+
+            var result = await new ProgramFixture(directory.FullName).Run("config", "migrate", "--output", "GitVersion.v7.yml");
+
+            result.ExitCode.ShouldBe(0);
+            var files = Directory.GetFiles(directory.FullName).Select(Path.GetFileName).ToArray();
+            files.Length.ShouldBe(2);
+            files.ShouldContain(ConfigurationFileLocator.DefaultFileName);
+            files.ShouldContain("GitVersion.v7.yml");
+            files.ShouldNotContain(file => file!.StartsWith(".", StringComparison.Ordinal));
+        }
+        finally
+        {
+            directory.Delete(recursive: true);
+        }
+    }
+
+    [Test]
     public async Task ConfigMigrateInPlaceMigratesExplicitConfigurationOutsideGitRepository()
     {
         var directory = Directory.CreateTempSubdirectory();
@@ -77,6 +101,29 @@ public class ConfigurationVersionIntegrationTests
             result.Output.ShouldBeEmpty();
             var migratedConfiguration = await File.ReadAllTextAsync(configurationPath);
             migratedConfiguration.ShouldContain("calculation:");
+        }
+        finally
+        {
+            directory.Delete(recursive: true);
+        }
+    }
+
+    [Test]
+    public async Task ConfigMigrateDoesNotEmitLegacyFallbackWarning()
+    {
+        var directory = Directory.CreateTempSubdirectory();
+        try
+        {
+            var configurationPath = Path.Combine(directory.FullName, ConfigurationFileLocator.DefaultFileName);
+            await File.WriteAllTextAsync(configurationPath, "next-version: 2.0.0");
+            var fixture = new ProgramFixture(directory.FullName);
+            fixture.WithEnv(new KeyValuePair<string, string>(ConfigurationVersionSelector.EnvironmentVariableName, "v6"));
+
+            var result = await fixture.Run("config", "migrate");
+
+            result.ExitCode.ShouldBe(0);
+            result.Output!.ShouldNotContain("temporary v6 compatibility mode");
+            result.Log!.ShouldNotContain("temporary v6 compatibility mode");
         }
         finally
         {

--- a/src/GitVersion.App.Tests/ConfigurationVersionIntegrationTests.cs
+++ b/src/GitVersion.App.Tests/ConfigurationVersionIntegrationTests.cs
@@ -5,8 +5,85 @@ using GitVersion.Helpers;
 namespace GitVersion.App.Tests;
 
 [TestFixture]
+[NonParallelizable]
 public class ConfigurationVersionIntegrationTests
 {
+    [Test]
+    public async Task ConfigMigrateWritesMigratedConfigurationToStandardOutput()
+    {
+        var directory = Directory.CreateTempSubdirectory();
+        try
+        {
+            var configurationPath = Path.Combine(directory.FullName, ConfigurationFileLocator.DefaultFileName);
+            await File.WriteAllTextAsync(configurationPath, "next-version: 2.0.0");
+
+            var result = await new ProgramFixture(directory.FullName).Run("config", "migrate");
+
+            result.ExitCode.ShouldBe(0);
+            result.Output.ShouldNotBeNull();
+            result.Output.ShouldContain("calculation:");
+            result.Output.ShouldContain("next-version: 2.0.0");
+            result.Output.ShouldContain("output: {}");
+        }
+        finally
+        {
+            directory.Delete(recursive: true);
+        }
+    }
+
+    [Test]
+    public async Task ConfigMigrateDoesNotOverwriteOutputWithoutForce()
+    {
+        var directory = Directory.CreateTempSubdirectory();
+        try
+        {
+            var configurationPath = Path.Combine(directory.FullName, ConfigurationFileLocator.DefaultFileName);
+            var outputPath = Path.Combine(directory.FullName, "GitVersion.v7.yml");
+            await File.WriteAllTextAsync(configurationPath, "next-version: 2.0.0");
+            await File.WriteAllTextAsync(outputPath, "existing configuration");
+
+            var result = await new ProgramFixture(directory.FullName).Run("config", "migrate", "--output", "GitVersion.v7.yml");
+
+            result.ExitCode.ShouldBe(1);
+            result.Output.ShouldBeEmpty();
+            var output = await File.ReadAllTextAsync(outputPath);
+            output.ShouldBe("existing configuration");
+
+            var forceResult = await new ProgramFixture(directory.FullName).Run("config", "migrate", "--output", "GitVersion.v7.yml", "--force");
+
+            forceResult.ExitCode.ShouldBe(0);
+            var forcedOutput = await File.ReadAllTextAsync(outputPath);
+            forcedOutput.ShouldContain("calculation:");
+        }
+        finally
+        {
+            directory.Delete(recursive: true);
+        }
+    }
+
+    [Test]
+    public async Task ConfigMigrateInPlaceMigratesExplicitConfigurationOutsideGitRepository()
+    {
+        var directory = Directory.CreateTempSubdirectory();
+        try
+        {
+            const string fileName = "legacy.yml";
+            var configurationPath = Path.Combine(directory.FullName, fileName);
+            await File.WriteAllTextAsync(configurationPath, "next-version: 2.0.0");
+
+            var result = await new ProgramFixture(directory.FullName).Run("config", "migrate", "--config", fileName, "--in-place");
+
+            result.ExitCode.ShouldBe(0);
+            result.Output.ShouldBeEmpty();
+            var migratedConfiguration = await File.ReadAllTextAsync(configurationPath);
+            migratedConfiguration.ShouldContain("calculation:");
+        }
+        finally
+        {
+            directory.Delete(recursive: true);
+        }
+    }
+
     [Test]
     public void V6AndV7ConfigurationCalculateTheSameVersion()
     {

--- a/src/GitVersion.App.Tests/HelpWriterTests.cs
+++ b/src/GitVersion.App.Tests/HelpWriterTests.cs
@@ -55,7 +55,12 @@ public class HelpWriterTests : TestBase
         var ignored = new[]
         {
             nameof(Arguments.Authentication),
-            nameof(Arguments.UpdateAssemblyInfoFileName)
+            nameof(Arguments.UpdateAssemblyInfoFileName),
+            nameof(Arguments.IsConfigurationMigration),
+            nameof(Arguments.MigrationInputFile),
+            nameof(Arguments.MigrationOutputFile),
+            nameof(Arguments.MigrationInPlace),
+            nameof(Arguments.MigrationForce)
         };
         typeof(Arguments).GetFields()
             .Select(p => p.Name)

--- a/src/GitVersion.App.Tests/LegacyArgumentParserTests.cs
+++ b/src/GitVersion.App.Tests/LegacyArgumentParserTests.cs
@@ -64,6 +64,14 @@ public class LegacyArgumentParserTests : TestBase
     }
 
     [Test]
+    public void ConfigMigrateIsRejectedAsASubcommand()
+    {
+        var exception = Should.Throw<WarningException>(() => this.argumentParser.ParseArguments("config migrate"));
+
+        exception.Message.ShouldContain("only available with the POSIX argument parser");
+    }
+
+    [Test]
     public void EmptyMeansUseCurrentDirectory()
     {
         var arguments = this.argumentParser.ParseArguments("");

--- a/src/GitVersion.App/ArgumentParser.cs
+++ b/src/GitVersion.App/ArgumentParser.cs
@@ -62,6 +62,11 @@ internal class ArgumentParser(
             return new Arguments { IsVersion = true };
         }
 
+        if (parseResult.CommandResult.Command == options.Migrate)
+        {
+            return MapMigrationValues(parseResult, options);
+        }
+
         var arguments = new Arguments();
         AddAuthentication(arguments);
         MapParsedValues(arguments, parseResult, options);
@@ -133,6 +138,32 @@ internal class ArgumentParser(
 
         MapRemoteOptions(arguments, parseResult, options);
         ApplyDefaults(arguments, parseResult, options);
+    }
+
+    private static Arguments MapMigrationValues(ParseResult parseResult, CommandOptions options)
+    {
+        var outputFile = parseResult.GetValue(options.MigrationOutputFile);
+        var inPlace = parseResult.GetValue(options.InPlace);
+        var force = parseResult.GetValue(options.Force);
+        if (outputFile is not null && inPlace)
+        {
+            throw new WarningException("Cannot use --output together with --in-place.");
+        }
+
+        if (force && outputFile is null)
+        {
+            throw new WarningException("--force can only be used together with --output.");
+        }
+
+        return new Arguments
+        {
+            IsConfigurationMigration = true,
+            MigrationInputFile = parseResult.GetValue(options.MigrationInputFile),
+            MigrationOutputFile = outputFile,
+            MigrationInPlace = inPlace,
+            MigrationForce = force,
+            TargetPath = parseResult.GetValue(options.TargetPath) ?? SysEnv.CurrentDirectory
+        };
     }
 
     private static void MapOutputOptions(Arguments arguments, ParseResult parseResult, CommandOptions options)
@@ -451,6 +482,17 @@ internal class ArgumentParser(
         {
             Description = "By default dynamic repositories will be cloned to %tmp%. Use this option to override"
         };
+        var configCommand = new Command("config", "Manages GitVersion configuration.");
+        var migrate = new Command("migrate", "Migrates a v6 configuration document to the v7 structure.");
+        var migrationInputFile = new Option<string?>("--config") { Description = "Path to the configuration file to migrate." };
+        var migrationOutputFile = new Option<string?>("--output") { Description = "Path to write the migrated configuration document." };
+        var inPlace = new Option<bool>("--in-place") { Description = "Replace the input configuration file." };
+        var force = new Option<bool>("--force") { Description = "Allow --output to replace an existing file." };
+        migrate.Options.Add(migrationInputFile);
+        migrate.Options.Add(migrationOutputFile);
+        migrate.Options.Add(inPlace);
+        migrate.Options.Add(force);
+        configCommand.Subcommands.Add(migrate);
 
         var rootCommand = new RootCommand("Use convention to derive a SemVer product version from a GitFlow or GitHub based repository.")
         {
@@ -481,6 +523,8 @@ internal class ArgumentParser(
             commit,
             dynamicRepoLocation
         };
+        rootCommand.Subcommands.Add(configCommand);
+        rootCommand.SetAction(_ => { });
 
         // Configure the built-in help system to wrap at 260 characters to avoid too small help messages
         var helpOption = rootCommand.Options.SingleOfType<HelpOption>();
@@ -497,7 +541,9 @@ internal class ArgumentParser(
             VerbosityOption: verbosity, UpdateAssemblyInfo: updateAssemblyInfo, UpdateProjectFiles: updateProjectFiles,
             EnsureAssemblyInfo: ensureAssemblyInfo, UpdateWixVersionFile: updateWixVersionFile,
             Url: url, Branch: branch, Username: username, Password: password,
-            Commit: commit, DynamicRepoLocation: dynamicRepoLocation
+            Commit: commit, DynamicRepoLocation: dynamicRepoLocation,
+            Migrate: migrate, MigrationInputFile: migrationInputFile, MigrationOutputFile: migrationOutputFile,
+            InPlace: inPlace, Force: force
         ));
     }
 
@@ -621,6 +667,11 @@ internal class ArgumentParser(
         Option<string?> Username,
         Option<string?> Password,
         Option<string?> Commit,
-        Option<string?> DynamicRepoLocation
+        Option<string?> DynamicRepoLocation,
+        Command Migrate,
+        Option<string?> MigrationInputFile,
+        Option<string?> MigrationOutputFile,
+        Option<bool> InPlace,
+        Option<bool> Force
     );
 }

--- a/src/GitVersion.App/Arguments.cs
+++ b/src/GitVersion.App/Arguments.cs
@@ -9,6 +9,11 @@ internal class Arguments
     public string? ConfigurationFile;
     public IReadOnlyDictionary<object, object?> OverrideConfiguration = new Dictionary<object, object?>();
     public bool ShowConfiguration;
+    public bool IsConfigurationMigration;
+    public string? MigrationInputFile;
+    public string? MigrationOutputFile;
+    public bool MigrationInPlace;
+    public bool MigrationForce;
 
     public string? TargetPath;
 
@@ -62,6 +67,15 @@ internal class Arguments
                 ConfigurationFile = this.ConfigurationFile,
                 OverrideConfiguration = this.OverrideConfiguration,
                 ShowConfiguration = this.ShowConfiguration
+            },
+
+            ConfigurationMigrationInfo =
+            {
+                IsMigration = this.IsConfigurationMigration,
+                InputFile = this.MigrationInputFile,
+                OutputFile = this.MigrationOutputFile,
+                InPlace = this.MigrationInPlace,
+                Force = this.MigrationForce
             },
 
             RepositoryInfo =

--- a/src/GitVersion.App/ConfigurationMigrationExecutor.cs
+++ b/src/GitVersion.App/ConfigurationMigrationExecutor.cs
@@ -46,7 +46,26 @@ internal class ConfigurationMigrationExecutor(
             this.logger.LogWarning("Replacing '{ConfigurationFile}'. Comments cannot be preserved during migration.", inputFile);
         }
 
-        this.fileSystem.File.WriteAllText(outputFile, migrated);
+        WriteAtomically(outputFile, migrated);
         return 0;
+    }
+
+    private void WriteAtomically(string outputFile, string migrated)
+    {
+        var directory = this.fileSystem.Path.GetDirectoryName(outputFile)!;
+        var temporaryFile = this.fileSystem.Path.Combine(directory, $".{this.fileSystem.Path.GetFileName(outputFile)}.{Guid.NewGuid():N}.tmp");
+
+        try
+        {
+            this.fileSystem.File.WriteAllText(temporaryFile, migrated);
+            this.fileSystem.File.Move(temporaryFile, outputFile, overwrite: true);
+        }
+        finally
+        {
+            if (this.fileSystem.File.Exists(temporaryFile))
+            {
+                this.fileSystem.File.Delete(temporaryFile);
+            }
+        }
     }
 }

--- a/src/GitVersion.App/ConfigurationMigrationExecutor.cs
+++ b/src/GitVersion.App/ConfigurationMigrationExecutor.cs
@@ -1,0 +1,52 @@
+using System.IO.Abstractions;
+using GitVersion.Configuration;
+using GitVersion.Extensions;
+
+namespace GitVersion;
+
+internal class ConfigurationMigrationExecutor(
+    IFileSystem fileSystem,
+    IConsole console,
+    ILogger<ConfigurationMigrationExecutor> logger,
+    IConfigurationFileLocator configurationFileLocator,
+    IConfigurationMigrationService migrationService) : IConfigurationMigrationExecutor
+{
+    private readonly IFileSystem fileSystem = fileSystem.NotNull();
+    private readonly IConsole console = console.NotNull();
+    private readonly ILogger<ConfigurationMigrationExecutor> logger = logger.NotNull();
+    private readonly IConfigurationFileLocator configurationFileLocator = configurationFileLocator.NotNull();
+    private readonly IConfigurationMigrationService migrationService = migrationService.NotNull();
+
+    public int Execute(GitVersionOptions options)
+    {
+        var migration = options.ConfigurationMigrationInfo;
+        var inputFile = migration.InputFile is null
+            ? this.configurationFileLocator.GetConfigurationFile(options.WorkingDirectory)
+            : Path.GetFullPath(migration.InputFile, options.WorkingDirectory);
+        if (inputFile is null || !this.fileSystem.File.Exists(inputFile))
+        {
+            throw new WarningException("Could not find a configuration file to migrate. Specify one with --config.");
+        }
+
+        var migrated = this.migrationService.Migrate(this.fileSystem.File.ReadAllText(inputFile));
+        if (!migration.InPlace && migration.OutputFile is null)
+        {
+            this.console.Write(migrated);
+            return 0;
+        }
+
+        var outputFile = migration.InPlace ? inputFile : Path.GetFullPath(migration.OutputFile!, options.WorkingDirectory);
+        if (!migration.InPlace && this.fileSystem.File.Exists(outputFile) && !migration.Force)
+        {
+            throw new WarningException($"The output file '{outputFile}' already exists. Use --force to replace it.");
+        }
+
+        if (migration.InPlace)
+        {
+            this.logger.LogWarning("Replacing '{ConfigurationFile}'. Comments cannot be preserved during migration.", inputFile);
+        }
+
+        this.fileSystem.File.WriteAllText(outputFile, migrated);
+        return 0;
+    }
+}

--- a/src/GitVersion.App/GitVersionApp.cs
+++ b/src/GitVersion.App/GitVersionApp.cs
@@ -5,10 +5,12 @@ namespace GitVersion;
 internal class GitVersionApp(
     IHostApplicationLifetime applicationLifetime,
     IGitVersionExecutor gitVersionExecutor,
+    IConfigurationMigrationExecutor configurationMigrationExecutor,
     IOptions<GitVersionOptions> options)
 {
     private readonly IHostApplicationLifetime applicationLifetime = applicationLifetime.NotNull();
     private readonly IGitVersionExecutor gitVersionExecutor = gitVersionExecutor.NotNull();
+    private readonly IConfigurationMigrationExecutor configurationMigrationExecutor = configurationMigrationExecutor.NotNull();
     private readonly IOptions<GitVersionOptions> options = options.NotNull();
 
     public Task RunAsync(CancellationToken _)
@@ -19,6 +21,10 @@ internal class GitVersionApp(
             if (gitVersionOptions.IsHelp || gitVersionOptions.IsVersion)
             {
                 SysEnv.ExitCode = 0;
+            }
+            else if (gitVersionOptions.ConfigurationMigrationInfo.IsMigration)
+            {
+                SysEnv.ExitCode = this.configurationMigrationExecutor.Execute(gitVersionOptions);
             }
             else
             {

--- a/src/GitVersion.App/GitVersionAppModule.cs
+++ b/src/GitVersion.App/GitVersionAppModule.cs
@@ -19,6 +19,7 @@ internal class GitVersionAppModule(string[]? args = null, bool useLegacyParser =
 
         services.AddSingleton<IGlobbingResolver, GlobbingResolver>();
         services.AddSingleton<IGitVersionExecutor, GitVersionExecutor>();
+        services.AddSingleton<IConfigurationMigrationExecutor, ConfigurationMigrationExecutor>();
         services.AddSingleton<GitVersionApp>();
 
         services.AddSingleton(sp =>

--- a/src/GitVersion.App/IConfigurationMigrationExecutor.cs
+++ b/src/GitVersion.App/IConfigurationMigrationExecutor.cs
@@ -1,0 +1,6 @@
+namespace GitVersion;
+
+internal interface IConfigurationMigrationExecutor
+{
+    int Execute(GitVersionOptions options);
+}

--- a/src/GitVersion.App/LegacyArgumentParser.cs
+++ b/src/GitVersion.App/LegacyArgumentParser.cs
@@ -78,6 +78,12 @@ internal class LegacyArgumentParser(
             return new Arguments { IsVersion = true };
         }
 
+        if (firstArgument.Equals("config", StringComparison.OrdinalIgnoreCase)
+            && commandLineArguments.Skip(1).FirstOrDefault()?.Equals("migrate", StringComparison.OrdinalIgnoreCase) == true)
+        {
+            throw new WarningException("The 'config migrate' command is only available with the POSIX argument parser.");
+        }
+
         var arguments = new Arguments();
 
         AddAuthentication(arguments);

--- a/src/GitVersion.Configuration.Tests/Configuration/ConfigurationMigrationServiceTests.cs
+++ b/src/GitVersion.Configuration.Tests/Configuration/ConfigurationMigrationServiceTests.cs
@@ -1,3 +1,5 @@
+using SharpYaml;
+
 namespace GitVersion.Configuration.Tests;
 
 [TestFixture]
@@ -45,6 +47,29 @@ public class ConfigurationMigrationServiceTests
     }
 
     [Test]
+    public void MigratesConfiguredValuesWithoutAddingDefaults()
+    {
+        const string input = """
+                             workflow: GitHubFlow/v1
+                             mode: ContinuousDeployment
+                             update-build-number: false
+                             branches:
+                               main:
+                                 increment: Minor
+                                 pre-release-weight: 42
+                             """;
+
+        var result = this.migrationService.Migrate(input);
+
+        result.ShouldContain("workflow: GitHubFlow/v1");
+        result.ShouldContain("mode: ContinuousDeployment");
+        result.ShouldContain("update-build-number: false");
+        result.ShouldContain("increment: Minor");
+        result.ShouldContain("pre-release-weight: 42");
+        result.ShouldNotContain("tag-prefix:");
+    }
+
+    [Test]
     public void RejectsMixedConfiguration()
     {
         const string input = """
@@ -53,5 +78,13 @@ public class ConfigurationMigrationServiceTests
                              """;
 
         Should.Throw<ConfigurationException>(() => this.migrationService.Migrate(input));
+    }
+
+    [Test]
+    public void RejectsMalformedYaml()
+    {
+        const string input = "branches: [";
+
+        Should.Throw<YamlException>(() => this.migrationService.Migrate(input));
     }
 }

--- a/src/GitVersion.Configuration.Tests/Configuration/ConfigurationMigrationServiceTests.cs
+++ b/src/GitVersion.Configuration.Tests/Configuration/ConfigurationMigrationServiceTests.cs
@@ -1,0 +1,57 @@
+namespace GitVersion.Configuration.Tests;
+
+[TestFixture]
+public class ConfigurationMigrationServiceTests
+{
+    private readonly IConfigurationMigrationService migrationService = new ConfigurationMigrationService(new ConfigurationSerializer());
+
+    [Test]
+    public void MigratesFlatConfigurationToCalculationAndOutputSections()
+    {
+        const string input = """
+                             workflow: GitFlow/v1
+                             tag-prefix: custom-
+                             update-build-number: false
+                             branches:
+                               main:
+                                 increment: Major
+                                 pre-release-weight: 42
+                             """;
+
+        var result = this.migrationService.Migrate(input);
+
+        result.ShouldContain("calculation:");
+        result.ShouldContain("  workflow: GitFlow/v1");
+        result.ShouldContain("  tag-prefix: custom-");
+        result.ShouldContain("      increment: Major");
+        result.ShouldContain("output:");
+        result.ShouldContain("  update-build-number: false");
+        result.ShouldContain("      pre-release-weight: 42");
+    }
+
+    [Test]
+    public void AcceptsNestedConfigurationAndProducesDeterministicOutput()
+    {
+        const string input = """
+                             output:
+                               update-build-number: false
+                             calculation:
+                               tag-prefix: custom-
+                             """;
+
+        var result = this.migrationService.Migrate(input);
+
+        this.migrationService.Migrate(result).ShouldBe(result);
+    }
+
+    [Test]
+    public void RejectsMixedConfiguration()
+    {
+        const string input = """
+                             calculation: {}
+                             tag-prefix: custom-
+                             """;
+
+        Should.Throw<ConfigurationException>(() => this.migrationService.Migrate(input));
+    }
+}

--- a/src/GitVersion.Configuration.Tests/Configuration/ConfigurationProviderTests.cs
+++ b/src/GitVersion.Configuration.Tests/Configuration/ConfigurationProviderTests.cs
@@ -417,14 +417,14 @@ public class ConfigurationProviderTests : TestBase
     }
 
     [Test]
-    public void NoWarnOnGitVersionYmlFile()
+    public void WarnsOnceWhenExplicitV6LoadsAConfigurationFile()
     {
         const string text = "";
         using var _ = this.fileSystem.SetupConfigFile(path: this.repoPath, text: text);
 
-        var stringLogger = string.Empty;
+        var logMessages = new List<string>();
 
-        var loggerFactory = new TestLoggerFactory(message => stringLogger = message);
+        var loggerFactory = new TestLoggerFactory(logMessages.Add);
 
         var options = Options.Create(new GitVersionOptions { WorkingDirectory = this.repoPath });
         var sp = ConfigureServices(services =>
@@ -435,9 +435,13 @@ public class ConfigurationProviderTests : TestBase
         this.configurationProvider = (ConfigurationProvider)sp.GetRequiredService<IConfigurationProvider>();
 
         this.configurationProvider.ProvideForDirectory(this.repoPath);
+        this.configurationProvider.ProvideForDirectory(this.repoPath);
 
         var filePath = FileSystemHelper.Path.Combine(this.repoPath, ConfigurationFileLocator.DefaultFileName);
-        stringLogger.ShouldContain($"Using configuration file '{filePath}'");
+        logMessages.ShouldContain(message => message.Contains($"Configuration file '{filePath}' uses the temporary v6 compatibility mode.", StringComparison.Ordinal));
+        logMessages.Count(message => message.Contains("temporary v6 compatibility mode", StringComparison.Ordinal)).ShouldBe(1);
+        logMessages.ShouldContain(message => message.Contains("GitVersion 7.1", StringComparison.Ordinal));
+        logMessages.ShouldContain(message => message.Contains("gitversion config migrate", StringComparison.Ordinal));
     }
 
     [Test]

--- a/src/GitVersion.Configuration.Tests/Configuration/ConfigurationProviderTests.cs
+++ b/src/GitVersion.Configuration.Tests/Configuration/ConfigurationProviderTests.cs
@@ -444,6 +444,45 @@ public class ConfigurationProviderTests : TestBase
         logMessages.ShouldContain(message => message.Contains("gitversion config migrate", StringComparison.Ordinal));
     }
 
+    [TestCase(null)]
+    [TestCase("v7")]
+    public void DoesNotWarnWhenV6IsNotExplicitlySelected(string? configurationVersion)
+    {
+        System.Environment.SetEnvironmentVariable(ConfigurationVersionSelector.EnvironmentVariableName, configurationVersion);
+        using var _ = this.fileSystem.SetupConfigFile(path: this.repoPath, text: "");
+        var logMessages = new List<string>();
+        var loggerFactory = new TestLoggerFactory(logMessages.Add);
+        var options = Options.Create(new GitVersionOptions { WorkingDirectory = this.repoPath });
+        var sp = ConfigureServices(services =>
+        {
+            services.AddSingleton(options);
+            loggerFactory.RegisterWith(services);
+        });
+        this.configurationProvider = (ConfigurationProvider)sp.GetRequiredService<IConfigurationProvider>();
+
+        this.configurationProvider.ProvideForDirectory(this.repoPath);
+
+        logMessages.ShouldNotContain(message => message.Contains("temporary v6 compatibility mode", StringComparison.Ordinal));
+    }
+
+    [Test]
+    public void DoesNotWarnForExplicitV6BuiltInDefaults()
+    {
+        var logMessages = new List<string>();
+        var loggerFactory = new TestLoggerFactory(logMessages.Add);
+        var options = Options.Create(new GitVersionOptions { WorkingDirectory = this.repoPath });
+        var sp = ConfigureServices(services =>
+        {
+            services.AddSingleton(options);
+            loggerFactory.RegisterWith(services);
+        });
+        this.configurationProvider = (ConfigurationProvider)sp.GetRequiredService<IConfigurationProvider>();
+
+        this.configurationProvider.ProvideForDirectory(this.repoPath);
+
+        logMessages.ShouldNotContain(message => message.Contains("temporary v6 compatibility mode", StringComparison.Ordinal));
+    }
+
     [Test]
     public void ShouldUseSpecifiedSourceBranchesForDevelop()
     {

--- a/src/GitVersion.Configuration/ConfigurationDocumentMapper.cs
+++ b/src/GitVersion.Configuration/ConfigurationDocumentMapper.cs
@@ -153,6 +153,34 @@ internal static class ConfigurationDocumentMapper
         };
     }
 
+    public static Dictionary<object, object?> Nest(IReadOnlyDictionary<object, object?> document)
+    {
+        Dictionary<object, object?> calculation = [];
+        Dictionary<object, object?> output = [];
+
+        foreach (var (key, value) in document)
+        {
+            if (key is string propertyName && propertyName.Equals(BranchesPropertyName, StringComparison.Ordinal))
+            {
+                SplitBranches(value, calculation, output);
+            }
+            else if (key is string outputPropertyName && OutputPropertyNames.Contains(outputPropertyName))
+            {
+                output[key] = CloneValue(value);
+            }
+            else
+            {
+                calculation[key] = CloneValue(value);
+            }
+        }
+
+        return new()
+        {
+            [CalculationSectionName] = calculation,
+            [OutputSectionName] = output
+        };
+    }
+
     public static bool IsOutputProperty(string propertyName) => OutputPropertyNames.Contains(propertyName);
 
     public static bool IsOutputBranchProperty(string propertyName) => OutputBranchPropertyNames.Contains(propertyName);
@@ -262,6 +290,56 @@ internal static class ConfigurationDocumentMapper
             foreach (var (propertyName, propertyValue) in branch)
             {
                 (OutputBranchPropertyNames.Contains(propertyName) ? outputBranch : calculationBranch)[propertyName] = propertyValue;
+            }
+
+            if (calculationBranch.Count != 0)
+            {
+                calculationBranches[branchName] = calculationBranch;
+            }
+
+            if (outputBranch.Count != 0)
+            {
+                outputBranches[branchName] = outputBranch;
+            }
+        }
+
+        if (calculationBranches.Count != 0)
+        {
+            calculation[BranchesPropertyName] = calculationBranches;
+        }
+
+        if (outputBranches.Count != 0)
+        {
+            output[BranchesPropertyName] = outputBranches;
+        }
+    }
+
+    private static void SplitBranches(
+        object? value,
+        IDictionary<object, object?> calculation,
+        IDictionary<object, object?> output)
+    {
+        if (value is not IReadOnlyDictionary<object, object?> branches)
+        {
+            calculation[BranchesPropertyName] = CloneValue(value);
+            return;
+        }
+
+        Dictionary<object, object?> calculationBranches = [];
+        Dictionary<object, object?> outputBranches = [];
+        foreach (var (branchName, branchValue) in branches)
+        {
+            if (branchValue is not IReadOnlyDictionary<object, object?> branch)
+            {
+                calculationBranches[branchName] = CloneValue(branchValue);
+                continue;
+            }
+
+            Dictionary<object, object?> calculationBranch = [];
+            Dictionary<object, object?> outputBranch = [];
+            foreach (var (propertyName, propertyValue) in branch)
+            {
+                (propertyName is string name && OutputBranchPropertyNames.Contains(name) ? outputBranch : calculationBranch)[propertyName] = CloneValue(propertyValue);
             }
 
             if (calculationBranch.Count != 0)

--- a/src/GitVersion.Configuration/ConfigurationMigrationService.cs
+++ b/src/GitVersion.Configuration/ConfigurationMigrationService.cs
@@ -1,0 +1,22 @@
+using GitVersion.Extensions;
+
+namespace GitVersion.Configuration;
+
+internal class ConfigurationMigrationService(IConfigurationSerializer configurationSerializer) : IConfigurationMigrationService
+{
+    private readonly IConfigurationSerializer configurationSerializer = configurationSerializer.NotNull();
+
+    public string Migrate(string input)
+    {
+        var document = this.configurationSerializer.Deserialize<Dictionary<object, object?>>(input);
+        return ConfigurationDocumentMapper.Detect(document) switch
+        {
+            ConfigurationDocumentKind.Empty or ConfigurationDocumentKind.V6 =>
+                this.configurationSerializer.SerializeDocument(ConfigurationDocumentMapper.Nest(document)),
+            ConfigurationDocumentKind.V7 => this.configurationSerializer.SerializeDocument(document),
+            _ => throw new ConfigurationException(
+                "The configuration document mixes the v6 flat configuration structure with the v7 'calculation'/'output' structure. " +
+                "Use only one structure before migrating.")
+        };
+    }
+}

--- a/src/GitVersion.Configuration/ConfigurationProvider.cs
+++ b/src/GitVersion.Configuration/ConfigurationProvider.cs
@@ -18,6 +18,7 @@ internal class ConfigurationProvider(
     private readonly ILogger<ConfigurationProvider> logger = logger.NotNull();
     private readonly IConfigurationSerializer configurationSerializer = configurationSerializer.NotNull();
     private readonly IOptions<GitVersionOptions> options = options.NotNull();
+    private bool legacyConfigurationWarningLogged;
 
     public IGitVersionConfiguration Provide(IReadOnlyDictionary<object, object?>? overrideConfiguration = null)
     {
@@ -46,6 +47,7 @@ internal class ConfigurationProvider(
         var configurationVersion = ConfigurationVersionSelector.Resolve();
         this.logger.LogInformation("Configuration version: {ConfigurationVersion}", ConfigurationVersionSelector.ResolveName());
         var configurationFromFile = ReadOverrideConfiguration(configFile);
+        WarnAboutExplicitLegacyConfiguration(configFile, configurationFromFile);
         var overrideConfigurationFromFile = configurationFromFile is null
             ? null
             : ConfigurationDocumentMapper.Normalize(configurationFromFile, configurationVersion, "configuration file");
@@ -100,6 +102,21 @@ internal class ConfigurationProvider(
         this.logger.LogInformation("Using configuration file '{ConfigFilePath}'", configFilePath);
         var content = this.fileSystem.File.ReadAllText(configFilePath);
         return this.configurationSerializer.Deserialize<Dictionary<object, object?>>(content);
+    }
+
+    private void WarnAboutExplicitLegacyConfiguration(string? configFilePath, Dictionary<object, object?>? configuration)
+    {
+        if (configuration is null || this.legacyConfigurationWarningLogged || !ConfigurationVersionSelector.IsExplicitV6())
+        {
+            return;
+        }
+
+        this.legacyConfigurationWarningLogged = true;
+        this.logger.LogWarning(
+            "Configuration file '{ConfigurationFile}' uses the temporary v6 compatibility mode. Legacy configuration loading is removed in GitVersion 7.1. " +
+            "Run 'gitversion config migrate' and validate with {ConfigurationVersion}=v7.",
+            configFilePath,
+            ConfigurationVersionSelector.EnvironmentVariableName);
     }
 
     private static string? GetWorkflow(IReadOnlyDictionary<object, object?>? overrideConfiguration, IReadOnlyDictionary<object, object?>? overrideConfigurationFromFile)

--- a/src/GitVersion.Configuration/ConfigurationSerializer.cs
+++ b/src/GitVersion.Configuration/ConfigurationSerializer.cs
@@ -47,6 +47,13 @@ internal class ConfigurationSerializer : IConfigurationSerializer
         return YamlSerializer.Serialize(OrderProperties(configuration), SerializerOptions);
     }
 
+    public string SerializeDocument(IReadOnlyDictionary<object, object?> document)
+    {
+        var yaml = SerializeLegacy(document);
+        var configuration = YamlSerializer.Deserialize<Dictionary<string, object?>>(yaml, SerializerOptions) ?? [];
+        return YamlSerializer.Serialize(OrderProperties(configuration), SerializerOptions);
+    }
+
     public static IGitVersionConfiguration? ReadConfiguration(string input)
         => DeserializeConfiguration(input, ConfigurationVersionSelector.Resolve(), "configuration document");
 

--- a/src/GitVersion.Configuration/GitVersionConfigurationModule.cs
+++ b/src/GitVersion.Configuration/GitVersionConfigurationModule.cs
@@ -8,6 +8,7 @@ public class GitVersionConfigurationModule : IGitVersionModule
     {
         services.AddSingleton<IGitVersionCacheKeyFactory, GitVersionCacheKeyFactory>();
         services.AddSingleton<IConfigurationSerializer, ConfigurationSerializer>();
+        services.AddSingleton<IConfigurationMigrationService, ConfigurationMigrationService>();
         services.AddSingleton<IConfigurationProvider, ConfigurationProvider>();
         services.AddSingleton<IConfigurationFileLocator, ConfigurationFileLocator>();
     }

--- a/src/GitVersion.Core.Tests/Core/ConfigurationVersionSelectorTests.cs
+++ b/src/GitVersion.Core.Tests/Core/ConfigurationVersionSelectorTests.cs
@@ -21,6 +21,17 @@ public class ConfigurationVersionSelectorTests : TestBase
         ConfigurationVersionSelector.Resolve().ShouldBe(isV6 ? ConfigurationVersion.V6 : ConfigurationVersion.V7);
     }
 
+    [TestCase(null, false)]
+    [TestCase("v6", true)]
+    [TestCase(" V6 ", true)]
+    [TestCase("v7", false)]
+    public void IdentifiesExplicitV6Selection(string? value, bool expected)
+    {
+        using var scope = new EnvironmentVariableScope(value);
+
+        ConfigurationVersionSelector.IsExplicitV6().ShouldBe(expected);
+    }
+
     [TestCase("6")]
     [TestCase("7")]
     [TestCase("true")]

--- a/src/GitVersion.Core/Configuration/ConfigurationVersion.cs
+++ b/src/GitVersion.Core/Configuration/ConfigurationVersion.cs
@@ -25,4 +25,7 @@ internal static class ConfigurationVersionSelector
     }
 
     public static string ResolveName() => Resolve() == ConfigurationVersion.V6 ? "v6" : "v7";
+
+    public static bool IsExplicitV6() =>
+        SysEnv.GetEnvironmentVariable(EnvironmentVariableName)?.Trim().Equals("v6", StringComparison.OrdinalIgnoreCase) == true;
 }

--- a/src/GitVersion.Core/Configuration/IConfigurationMigrationService.cs
+++ b/src/GitVersion.Core/Configuration/IConfigurationMigrationService.cs
@@ -1,0 +1,6 @@
+namespace GitVersion.Configuration;
+
+internal interface IConfigurationMigrationService
+{
+    string Migrate(string input);
+}

--- a/src/GitVersion.Core/Configuration/IConfigurationSerializer.cs
+++ b/src/GitVersion.Core/Configuration/IConfigurationSerializer.cs
@@ -4,4 +4,5 @@ internal interface IConfigurationSerializer
 {
     T Deserialize<T>(string input);
     string Serialize(object graph);
+    string SerializeDocument(IReadOnlyDictionary<object, object?> document);
 }

--- a/src/GitVersion.Core/Options/ConfigurationMigrationInfo.cs
+++ b/src/GitVersion.Core/Options/ConfigurationMigrationInfo.cs
@@ -1,0 +1,20 @@
+namespace GitVersion;
+
+/// <summary>Settings that control a configuration migration operation.</summary>
+public class ConfigurationMigrationInfo
+{
+    /// <summary>Gets or sets a value indicating whether the configuration migration command should be executed.</summary>
+    public bool IsMigration { get; set; }
+
+    /// <summary>Gets or sets the configuration file to migrate.</summary>
+    public string? InputFile { get; set; }
+
+    /// <summary>Gets or sets the file to which the migrated configuration should be written.</summary>
+    public string? OutputFile { get; set; }
+
+    /// <summary>Gets or sets a value indicating whether the source configuration file should be replaced.</summary>
+    public bool InPlace { get; set; }
+
+    /// <summary>Gets or sets a value indicating whether an existing output file may be replaced.</summary>
+    public bool Force { get; set; }
+}

--- a/src/GitVersion.Core/Options/GitVersionOptions.cs
+++ b/src/GitVersion.Core/Options/GitVersionOptions.cs
@@ -17,6 +17,9 @@ public class GitVersionOptions
     /// <summary>Gets the settings that control how the GitVersion configuration file is located and applied.</summary>
     public ConfigurationInfo ConfigurationInfo { get; } = new();
 
+    /// <summary>Gets the settings that control configuration migration.</summary>
+    public ConfigurationMigrationInfo ConfigurationMigrationInfo { get; } = new();
+
     /// <summary>Gets the repository-targeting settings (URL, branch, commit, clone path).</summary>
     public RepositoryInfo RepositoryInfo { get; } = new();
 

--- a/src/GitVersion.Core/PublicAPI.Unshipped.txt
+++ b/src/GitVersion.Core/PublicAPI.Unshipped.txt
@@ -1,4 +1,17 @@
 #nullable enable
+GitVersion.ConfigurationMigrationInfo
+GitVersion.ConfigurationMigrationInfo.ConfigurationMigrationInfo() -> void
+GitVersion.ConfigurationMigrationInfo.Force.get -> bool
+GitVersion.ConfigurationMigrationInfo.Force.set -> void
+GitVersion.ConfigurationMigrationInfo.InPlace.get -> bool
+GitVersion.ConfigurationMigrationInfo.InPlace.set -> void
+GitVersion.ConfigurationMigrationInfo.InputFile.get -> string?
+GitVersion.ConfigurationMigrationInfo.InputFile.set -> void
+GitVersion.ConfigurationMigrationInfo.IsMigration.get -> bool
+GitVersion.ConfigurationMigrationInfo.IsMigration.set -> void
+GitVersion.ConfigurationMigrationInfo.OutputFile.get -> string?
+GitVersion.ConfigurationMigrationInfo.OutputFile.set -> void
+GitVersion.GitVersionOptions.ConfigurationMigrationInfo.get -> GitVersion.ConfigurationMigrationInfo!
 GitVersion.Configuration.EffectiveConfiguration.CustomVersionFormat.get -> string?
 GitVersion.Configuration.EffectiveConfiguration.VersionBumpResetMessage.get -> string?
 GitVersion.Configuration.IBranchConfiguration.CustomVersionFormat.get -> string?


### PR DESCRIPTION
Implements GitTools/GitVersion#5133.

Adds raw-document v6-to-v7 migration through `gitversion config migrate`, safe output handling, POSIX-only command routing, and explicit-v6 compatibility warnings.

Validation: focused configuration and app tests, solution build, and formatting verification.