### PR TITLE
Document v7 configuration layout and migration

### DIFF
--- a/BREAKING_CHANGES.md
+++ b/BREAKING_CHANGES.md
@@ -55,6 +55,26 @@ The command-line interface has been migrated from Windows-style (`/switch` and s
 
 As a temporary migration aid, set the environment variable `GITVERSION_USE_V6_ARGUMENT_PARSER=true` to restore the legacy `/switch` and `-switch` argument handling. This escape hatch will be removed in a future release.
 
+### Configuration structure and migration
+
+v7 configuration now separates calculation from output:
+
+```yaml
+calculation:
+  branches:
+    main:
+      increment: Patch
+output:
+  update-build-number: true
+```
+
+v7.0 defaults to the nested layout. `GITVERSION_CONFIGURATION_VERSION=v6` is a
+temporary flat-layout fallback that logs a migration warning for user files.
+Convert files with `gitversion config migrate`. The command
+writes YAML to stdout by default, supports `--config`, `--output`,
+`--in-place`, and `--force`, and warns that comments cannot be preserved when
+replacing a file.
+
 #### Full argument mapping
 
 | Old argument                  | New argument                     | Short alias                    | Env var alternative          |

--- a/docs/input/docs/migration/v6-to-v7.md
+++ b/docs/input/docs/migration/v6-to-v7.md
@@ -117,6 +117,25 @@ gitversion --url https://github.com/org/repo.git --branch main --username user -
 
 For current command details and examples, see [CLI Arguments](/docs/usage/cli/arguments).
 
+## Configuration migration
+
+GitVersion v7 stores settings under `calculation` and `output`. Convert an
+existing flat v6 YAML document with the POSIX-only migration command:
+
+```shell
+gitversion config migrate
+gitversion config migrate --config GitVersion.yml --output GitVersion.v7.yml
+gitversion config migrate --config GitVersion.yml --in-place
+```
+
+The first command discovers `GitVersion.yml` and emits v7 YAML to stdout.
+`--output` requires `--force` to replace an existing file and cannot be used
+with `--in-place`. In-place migration warns because comments cannot be
+preserved. The command does not need a Git repository and migrating its v7
+output again is idempotent. In v7.0, you can temporarily validate a flat file
+with `GITVERSION_CONFIGURATION_VERSION=v6`; GitVersion warns once for that
+fallback.
+
 ## Git backend
 
 GitVersion v7 introduces a fully managed Git backend as an alternative to the native LibGit2Sharp (libgit2) implementation. The backend is selected with the `GITVERSION_GIT_BACKEND` environment variable. When the variable is not set (or empty), the release's default backend is used — you never need to set it. Setting it to any value other than `libgit2` or `managed` (case-insensitive) is an error: GitVersion fails fast instead of silently running the default backend with a typo unnoticed.
@@ -138,7 +157,8 @@ The environment variables relevant to migrating from v6 to v7:
 
 | Variable                            | Purpose                                                                                                             |
 | ----------------------------------- | ------------------------------------------------------------------------------------------------------------------- |
-| `GITVERSION_GIT_BACKEND`            | Selects the Git backend: `libgit2` (default in v7.0) or `managed`. See [Git backend](#git-backend).                 |
+| `GITVERSION_CONFIGURATION_VERSION`   | Selects the configuration layout: `v7` (default) or temporary flat `v6` fallback.                                   |
+| `GITVERSION_GIT_BACKEND`             | Selects the Git backend: `libgit2` (default in v7.0) or `managed`. See [Git backend](#git-backend).                 |
 | `GITVERSION_USE_V6_ARGUMENT_PARSER` | Set to `true` to temporarily restore the legacy v6 (`/switch`) argument parser. Removed in a future release.        |
 | `GITVERSION_REMOTE_USERNAME`        | Alternative to `--username` for dynamic-repository credentials.                                                     |
 | `GITVERSION_REMOTE_PASSWORD`        | Alternative to `--password` for dynamic-repository credentials.                                                     |

--- a/docs/input/docs/reference/configuration.md
+++ b/docs/input/docs/reference/configuration.md
@@ -21,6 +21,72 @@ found that is generally what is needed when using GitFlow.
 To see the effective configuration (defaults and overrides), you can run
 `gitversion --show-config`.
 
+## v7 configuration layout
+
+GitVersion v7 separates version **calculation** from version **output**. Put
+calculation settings under `calculation` and settings that format or publish
+the calculated version under `output`:
+
+```yaml
+calculation:
+  workflow: GitHubFlow/v1
+  branches:
+    main:
+      increment: Patch
+output:
+  update-build-number: true
+  branches:
+    main:
+      pre-release-weight: 55000
+```
+
+`calculation.branches` contains branch-discovery and version-calculation
+settings. `output.branches` contains branch-specific output settings. A branch
+may appear in either section or both; GitVersion combines both sections into
+one effective branch configuration.
+
+| v6 flat setting | v7 location |
+| --- | --- |
+| `assembly-file-versioning-format`, `assembly-file-versioning-scheme`, `assembly-informational-format`, `assembly-versioning-format`, `assembly-versioning-scheme`, `commit-date-format`, `custom-version-format`, `pre-release-weight`, `tag-pre-release-weight`, `update-build-number` | `output.<setting>` |
+| Every other root setting, including `branches`, `ignore`, `next-version`, `strategies`, `tag-prefix`, and `workflow` | `calculation.<setting>` |
+| Branch `custom-version-format`, `pre-release-weight` | `output.branches.<branch>.<setting>` |
+| Every other branch setting, including `increment`, `label`, `mode`, `regex`, and `source-branches` | `calculation.branches.<branch>.<setting>` |
+
+In v7, `gitversion --show-config` emits this nested structure. The temporary
+v6 flat format can be selected only with
+`GITVERSION_CONFIGURATION_VERSION=v6` in v7.0; GitVersion warns when it loads
+a user configuration that way.
+
+### Migrating an existing configuration
+
+Use the POSIX-only migration command to convert a v6 document without opening
+a repository:
+
+```shell
+# Discover GitVersion.yml in the target/current directory and write YAML to stdout
+gitversion config migrate
+
+# Select an input explicitly, write a new file, or replace that input
+gitversion config migrate --config GitVersion.yml --output GitVersion.v7.yml
+gitversion config migrate --config GitVersion.yml --in-place
+```
+
+`--output` refuses to overwrite an existing file unless `--force` is supplied;
+`--output` and `--in-place` cannot be combined. `--in-place` warns because
+comments cannot be preserved. The command is deterministic: migrating an
+already nested v7 document produces the same YAML again.
+
+### Overriding v7 configuration
+
+`--override-config` uses the selected configuration structure. With the v7
+default, use nested keys such as
+`--override-config calculation.tag-prefix='[vV]?'` and
+`--override-config output.update-build-number=false`. Branch overrides follow
+the same ownership map, for example
+`calculation.branches.main.increment=Patch` and
+`output.branches.main.pre-release-weight=55000`. Flat v6 keys are rejected in
+v7 mode with their nested replacement.
+
 ## Global configuration
 
 The following supported workflow configurations are available in GitVersion and can be referenced by the workflow property:
@@ -494,6 +560,8 @@ expression with `(?-i)`, for example `(?-i)^experimental-`.
 
 ### assembly-file-versioning-format
 
+This is an `output` setting: `output.assembly-file-versioning-format`.
+
 Specifies the format of `AssemblyFileVersion` and
 overwrites the value of `assembly-file-versioning-scheme`.
 
@@ -502,16 +570,21 @@ or a process-scoped environment variable (when prefixed with `env:`).  For examp
 
 ```yaml
 # use a variable if non-null or a fallback value otherwise
-assembly-file-versioning-format: '{Major}.{Minor}.{Patch}.{WeightedPreReleaseNumber ?? 0}'
+output:
+  assembly-file-versioning-format: '{Major}.{Minor}.{Patch}.{WeightedPreReleaseNumber ?? 0}'
 
 # use an environment variable or raise an error if not available
-assembly-file-versioning-format: '{Major}.{Minor}.{Patch}.{env:BUILD_NUMBER}'
+output:
+  assembly-file-versioning-format: '{Major}.{Minor}.{Patch}.{env:BUILD_NUMBER}'
 
 # use an environment variable if available or a fallback value otherwise
-assembly-file-versioning-format: '{Major}.{Minor}.{Patch}.{env:BUILD_NUMBER ?? 42}'
+output:
+  assembly-file-versioning-format: '{Major}.{Minor}.{Patch}.{env:BUILD_NUMBER ?? 42}'
 ```
 
 ### assembly-file-versioning-scheme
+
+This is an `output` setting: `output.assembly-file-versioning-scheme`.
 
 When updating assembly info, `assembly-file-versioning-scheme` tells GitVersion
 how to treat the `AssemblyFileVersion` attribute. Note: you can use `None` to
@@ -521,17 +594,23 @@ skip updating the `AssemblyFileVersion` while still updating the
 
 ### assembly-informational-format
 
+This is an `output` setting: `output.assembly-informational-format`.
+
 Specifies the format of `AssemblyInformationalVersion`.
 Follows the same formatting semantics as `assembly-file-versioning-format`.
 The default value is `{InformationalVersion}`.
 
 ### assembly-versioning-format
 
+This is an `output` setting: `output.assembly-versioning-format`.
+
 Specifies the format of `AssemblyVersion` and
 overwrites the value of `assembly-versioning-scheme`.
 Follows the same formatting semantics as `assembly-file-versioning-format`.
 
 ### assembly-versioning-scheme
+
+This is an `output` setting: `output.assembly-versioning-scheme`.
 
 When updating assembly info, `assembly-versioning-scheme` tells GitVersion how
 to treat the `AssemblyVersion` attribute. Useful to lock the major when using
@@ -582,22 +661,26 @@ a named capture group called `Number`.
 **Example usage:**
 
 ```yaml
-branches:
-  pull-request:
-    mode: ContinuousDelivery
-    label: PullRequest{Number}
-    increment: Inherit
-    prevent-increment:
-      of-merged-branch: true
-      when-current-commit-tagged: false
-    track-merge-message: true
-    regex: ^(pull-requests|pull|pr)[\/-](?<Number>\d*)
-    source-branches:
-    - main
-    - release
-    - feature
-    is-source-branch-for: []
-    pre-release-weight: 30000
+calculation:
+  branches:
+    pull-request:
+      mode: ContinuousDelivery
+      label: PullRequest{Number}
+      increment: Inherit
+      prevent-increment:
+        of-merged-branch: true
+        when-current-commit-tagged: false
+      track-merge-message: true
+      regex: ^(pull-requests|pull|pr)[\/-](?<Number>\d*)
+      source-branches:
+      - main
+      - release
+      - feature
+      is-source-branch-for: []
+output:
+  branches:
+    pull-request:
+      pre-release-weight: 30000
 ```
 
 ### mode
@@ -605,6 +688,9 @@ branches:
 Same as for the [global configuration, explained above](#mode).
 
 ### pre-release-weight
+
+This is an output setting: `output.pre-release-weight` globally or
+`output.branches.<branch>.pre-release-weight` for a branch.
 
 Provides a way to translate the `PreReleaseLabelName` ([variables][variables]) to a numeric
 value in order to avoid version collisions across different branches. For
@@ -658,6 +744,8 @@ Indicates this branch config represents develop in GitFlow.
 
 ### commit-date-format
 
+This is an `output` setting: `output.commit-date-format`.
+
 Sets the format which will be used to format the `CommitDate` output variable.
 
 ### commit-message-incrementing
@@ -667,6 +755,9 @@ in the commit message. See the `*-version-bump-message` options above for
 details on the syntax. Default set to `Enabled`; set to `Disabled` to disable.
 
 ### custom-version-format
+
+This is an `output` setting: `output.custom-version-format` globally or
+`output.branches.<branch>.custom-version-format` for a branch.
 
 Specifies the format of the `CustomVersion` output variable.
 Follows the same formatting semantics as `assembly-file-versioning-format` and
@@ -695,10 +786,11 @@ semantics, and `^` and `$` can be used to anchor a match. To require
 case-sensitive matching, prefix a pattern with `(?-i)`.
 
 ```yaml
-ignore:
-  branches:
-    - ^experimental/
-    - ^release/legacy$
+calculation:
+  ignore:
+    branches:
+      - ^experimental/
+      - ^release/legacy$
 ```
 
 The current branch and an explicitly requested target branch remain available
@@ -727,9 +819,10 @@ Date and time in the format `yyyy-MM-ddTHH:mm:ss` (eg `commits-before:
 A sequence of regular expressions that represent paths in the repository. Commits that modify these paths will be excluded from version calculations. For example, to filter out commits that belong to `docs`:
 
 ```yaml
-ignore:
-  paths:
-    - ^docs\/
+calculation:
+  ignore:
+    paths:
+      - ^docs\/
 ```
 
 ##### *Monorepo*
@@ -740,17 +833,19 @@ As an example, consider a monorepo consisting of subdirectories for `ProjectA`, 
 * Specific match on `/ProjectB/*`:
 
 ```yaml
-ignore:
-  paths:
-    - `^\/ProductB\/.*`
+calculation:
+  ignore:
+    paths:
+      - `^\/ProductB\/.*`
 ```
 
 * Negative lookahead on anything other than `/ProjectA/*` and `/LibraryC/*`:
 
 ```yaml
-ignore:
-  paths:
-    - `^(?!\/ProductA\/|\/LibraryC\/).*`
+calculation:
+  ignore:
+    paths:
+      - `^(?!\/ProductA\/|\/LibraryC\/).*`
 ```
 
 A commit having changes only in `/ProjectB/*` path would be ignored. A commit having changes in the following paths wouldn't be ignored:
@@ -779,17 +874,19 @@ there is a rogue commit in history yielding a bad version. You can use either
 style below:
 
 ```yaml
-ignore:
-  sha: [e7bc24c0f34728a25c9187b8d0b041d935763e3a, 764e16321318f2fdb9cdeaa56d1156a1cba307d7]
+calculation:
+  ignore:
+    sha: [e7bc24c0f34728a25c9187b8d0b041d935763e3a, 764e16321318f2fdb9cdeaa56d1156a1cba307d7]
 ```
 
 or
 
 ```yaml
-ignore:
-  sha:
-    - e7bc24c0f34728a25c9187b8d0b041d935763e3a
-    - 764e16321318f2fdb9cdeaa56d1156a1cba307d7
+calculation:
+  ignore:
+    sha:
+      - e7bc24c0f34728a25c9187b8d0b041d935763e3a
+      - 764e16321318f2fdb9cdeaa56d1156a1cba307d7
 ```
 
 #### tags
@@ -801,10 +898,11 @@ use OR semantics, and `^` and `$` can be used to anchor a match. To require
 case-sensitive matching, prefix a pattern with `(?-i)`.
 
 ```yaml
-ignore:
-  tags:
-    - ^experimental-
-    - ^v0\.
+calculation:
+  ignore:
+    tags:
+      - ^experimental-
+      - ^v0\.
 ```
 
 Ignoring a tag does not ignore the commit it points to. The commit remains part
@@ -838,23 +936,25 @@ branch.
 A complete example:
 
 ```yaml
-branches:
-  unstable:
-    regex: ...
-    is-source-branch-for: ['main', 'develop', 'feature', 'hotfix', 'support']
+calculation:
+  branches:
+    unstable:
+      regex: ...
+      is-source-branch-for: ['main', 'develop', 'feature', 'hotfix', 'support']
 ```
 
 Without this configuration value you would have to do:
 
 ```yaml
-branches:
-  unstable:
-    regex:
-  feature:
-    source-branches: ['unstable', 'develop', 'feature', 'hotfix', 'support']
-  release:
-    source-branches: ['unstable', 'develop']
-  etc...
+calculation:
+  branches:
+    unstable:
+      regex:
+    feature:
+      source-branches: ['unstable', 'develop', 'feature', 'hotfix', 'support']
+    release:
+      source-branches: ['unstable', 'develop']
+    etc...
 ```
 
 ### major-version-bump-message
@@ -1038,7 +1138,12 @@ Configures GitVersion to update the build number or not when running on a build 
 
 ## Branch configuration
 
-Then we have branch specific configuration, which looks something like this:
+The following **v4 migration example** illustrates the change from regular-expression
+keys to named branch configurations. It uses the legacy flat layout and is retained
+only for that historical migration context; it is not a valid v7 configuration. For
+new v7 configuration, place branch calculation settings under `calculation.branches`
+and branch output settings under `output.branches`, as shown in the [v7 configuration
+layout](#v7-configuration-layout).
 
 :::{.alert .alert-info}
 **Note**
@@ -1046,8 +1151,7 @@ Then we have branch specific configuration, which looks something like this:
 v4 changed from using regexes for keys, to named configs
 :::
 
-If you have branch specific configuration upgrading to v4 will force you to
-upgrade.
+If you have branch-specific configuration, upgrading to v4 required this change.
 
 ```yaml
 workflow: 'GitHubFlow/v1'

--- a/docs/input/docs/reference/mdsource/configuration.source.md
+++ b/docs/input/docs/reference/mdsource/configuration.source.md
@@ -21,6 +21,72 @@ found that is generally what is needed when using GitFlow.
 To see the effective configuration (defaults and overrides), you can run
 `gitversion --show-config`.
 
+## v7 configuration layout
+
+GitVersion v7 separates version **calculation** from version **output**. Put
+calculation settings under `calculation` and settings that format or publish
+the calculated version under `output`:
+
+```yaml
+calculation:
+  workflow: GitHubFlow/v1
+  branches:
+    main:
+      increment: Patch
+output:
+  update-build-number: true
+  branches:
+    main:
+      pre-release-weight: 55000
+```
+
+`calculation.branches` contains branch-discovery and version-calculation
+settings. `output.branches` contains branch-specific output settings. A branch
+may appear in either section or both; GitVersion combines both sections into
+one effective branch configuration.
+
+| v6 flat setting | v7 location |
+| --- | --- |
+| `assembly-file-versioning-format`, `assembly-file-versioning-scheme`, `assembly-informational-format`, `assembly-versioning-format`, `assembly-versioning-scheme`, `commit-date-format`, `custom-version-format`, `pre-release-weight`, `tag-pre-release-weight`, `update-build-number` | `output.<setting>` |
+| Every other root setting, including `branches`, `ignore`, `next-version`, `strategies`, `tag-prefix`, and `workflow` | `calculation.<setting>` |
+| Branch `custom-version-format`, `pre-release-weight` | `output.branches.<branch>.<setting>` |
+| Every other branch setting, including `increment`, `label`, `mode`, `regex`, and `source-branches` | `calculation.branches.<branch>.<setting>` |
+
+In v7, `gitversion --show-config` emits this nested structure. The temporary
+v6 flat format can be selected only with
+`GITVERSION_CONFIGURATION_VERSION=v6` in v7.0; GitVersion warns when it loads
+a user configuration that way.
+
+### Migrating an existing configuration
+
+Use the POSIX-only migration command to convert a v6 document without opening
+a repository:
+
+```shell
+# Discover GitVersion.yml in the target/current directory and write YAML to stdout
+gitversion config migrate
+
+# Select an input explicitly, write a new file, or replace that input
+gitversion config migrate --config GitVersion.yml --output GitVersion.v7.yml
+gitversion config migrate --config GitVersion.yml --in-place
+```
+
+`--output` refuses to overwrite an existing file unless `--force` is supplied;
+`--output` and `--in-place` cannot be combined. `--in-place` warns because
+comments cannot be preserved. The command is deterministic: migrating an
+already nested v7 document produces the same YAML again.
+
+### Overriding v7 configuration
+
+`--override-config` uses the selected configuration structure. With the v7
+default, use nested keys such as
+`--override-config calculation.tag-prefix='[vV]?'` and
+`--override-config output.update-build-number=false`. Branch overrides follow
+the same ownership map, for example
+`calculation.branches.main.increment=Patch` and
+`output.branches.main.pre-release-weight=55000`. Flat v6 keys are rejected in
+v7 mode with their nested replacement.
+
 ## Global configuration
 
 The following supported workflow configurations are available in GitVersion and can be referenced by the workflow property:
@@ -61,6 +127,8 @@ expression with `(?-i)`, for example `(?-i)^experimental-`.
 
 ### assembly-file-versioning-format
 
+This is an `output` setting: `output.assembly-file-versioning-format`.
+
 Specifies the format of `AssemblyFileVersion` and
 overwrites the value of `assembly-file-versioning-scheme`.
 
@@ -69,16 +137,21 @@ or a process-scoped environment variable (when prefixed with `env:`).  For examp
 
 ```yaml
 # use a variable if non-null or a fallback value otherwise
-assembly-file-versioning-format: '{Major}.{Minor}.{Patch}.{WeightedPreReleaseNumber ?? 0}'
+output:
+  assembly-file-versioning-format: '{Major}.{Minor}.{Patch}.{WeightedPreReleaseNumber ?? 0}'
 
 # use an environment variable or raise an error if not available
-assembly-file-versioning-format: '{Major}.{Minor}.{Patch}.{env:BUILD_NUMBER}'
+output:
+  assembly-file-versioning-format: '{Major}.{Minor}.{Patch}.{env:BUILD_NUMBER}'
 
 # use an environment variable if available or a fallback value otherwise
-assembly-file-versioning-format: '{Major}.{Minor}.{Patch}.{env:BUILD_NUMBER ?? 42}'
+output:
+  assembly-file-versioning-format: '{Major}.{Minor}.{Patch}.{env:BUILD_NUMBER ?? 42}'
 ```
 
 ### assembly-file-versioning-scheme
+
+This is an `output` setting: `output.assembly-file-versioning-scheme`.
 
 When updating assembly info, `assembly-file-versioning-scheme` tells GitVersion
 how to treat the `AssemblyFileVersion` attribute. Note: you can use `None` to
@@ -88,17 +161,23 @@ skip updating the `AssemblyFileVersion` while still updating the
 
 ### assembly-informational-format
 
+This is an `output` setting: `output.assembly-informational-format`.
+
 Specifies the format of `AssemblyInformationalVersion`.
 Follows the same formatting semantics as `assembly-file-versioning-format`.
 The default value is `{InformationalVersion}`.
 
 ### assembly-versioning-format
 
+This is an `output` setting: `output.assembly-versioning-format`.
+
 Specifies the format of `AssemblyVersion` and
 overwrites the value of `assembly-versioning-scheme`.
 Follows the same formatting semantics as `assembly-file-versioning-format`.
 
 ### assembly-versioning-scheme
+
+This is an `output` setting: `output.assembly-versioning-scheme`.
 
 When updating assembly info, `assembly-versioning-scheme` tells GitVersion how
 to treat the `AssemblyVersion` attribute. Useful to lock the major when using
@@ -149,22 +228,26 @@ a named capture group called `Number`.
 **Example usage:**
 
 ```yaml
-branches:
-  pull-request:
-    mode: ContinuousDelivery
-    label: PullRequest{Number}
-    increment: Inherit
-    prevent-increment:
-      of-merged-branch: true
-      when-current-commit-tagged: false
-    track-merge-message: true
-    regex: ^(pull-requests|pull|pr)[\/-](?<Number>\d*)
-    source-branches:
-    - main
-    - release
-    - feature
-    is-source-branch-for: []
-    pre-release-weight: 30000
+calculation:
+  branches:
+    pull-request:
+      mode: ContinuousDelivery
+      label: PullRequest{Number}
+      increment: Inherit
+      prevent-increment:
+        of-merged-branch: true
+        when-current-commit-tagged: false
+      track-merge-message: true
+      regex: ^(pull-requests|pull|pr)[\/-](?<Number>\d*)
+      source-branches:
+      - main
+      - release
+      - feature
+      is-source-branch-for: []
+output:
+  branches:
+    pull-request:
+      pre-release-weight: 30000
 ```
 
 ### mode
@@ -172,6 +255,9 @@ branches:
 Same as for the [global configuration, explained above](#mode).
 
 ### pre-release-weight
+
+This is an output setting: `output.pre-release-weight` globally or
+`output.branches.<branch>.pre-release-weight` for a branch.
 
 Provides a way to translate the `PreReleaseLabelName` ([variables][variables]) to a numeric
 value in order to avoid version collisions across different branches. For
@@ -225,6 +311,8 @@ Indicates this branch config represents develop in GitFlow.
 
 ### commit-date-format
 
+This is an `output` setting: `output.commit-date-format`.
+
 Sets the format which will be used to format the `CommitDate` output variable.
 
 ### commit-message-incrementing
@@ -234,6 +322,9 @@ in the commit message. See the `*-version-bump-message` options above for
 details on the syntax. Default set to `Enabled`; set to `Disabled` to disable.
 
 ### custom-version-format
+
+This is an `output` setting: `output.custom-version-format` globally or
+`output.branches.<branch>.custom-version-format` for a branch.
 
 Specifies the format of the `CustomVersion` output variable.
 Follows the same formatting semantics as `assembly-file-versioning-format` and
@@ -262,10 +353,11 @@ semantics, and `^` and `$` can be used to anchor a match. To require
 case-sensitive matching, prefix a pattern with `(?-i)`.
 
 ```yaml
-ignore:
-  branches:
-    - ^experimental/
-    - ^release/legacy$
+calculation:
+  ignore:
+    branches:
+      - ^experimental/
+      - ^release/legacy$
 ```
 
 The current branch and an explicitly requested target branch remain available
@@ -294,9 +386,10 @@ Date and time in the format `yyyy-MM-ddTHH:mm:ss` (eg `commits-before:
 A sequence of regular expressions that represent paths in the repository. Commits that modify these paths will be excluded from version calculations. For example, to filter out commits that belong to `docs`:
 
 ```yaml
-ignore:
-  paths:
-    - ^docs\/
+calculation:
+  ignore:
+    paths:
+      - ^docs\/
 ```
 
 ##### *Monorepo*
@@ -307,17 +400,19 @@ As an example, consider a monorepo consisting of subdirectories for `ProjectA`, 
 * Specific match on `/ProjectB/*`:
 
 ```yaml
-ignore:
-  paths:
-    - `^\/ProductB\/.*`
+calculation:
+  ignore:
+    paths:
+      - `^\/ProductB\/.*`
 ```
 
 * Negative lookahead on anything other than `/ProjectA/*` and `/LibraryC/*`:
 
 ```yaml
-ignore:
-  paths:
-    - `^(?!\/ProductA\/|\/LibraryC\/).*`
+calculation:
+  ignore:
+    paths:
+      - `^(?!\/ProductA\/|\/LibraryC\/).*`
 ```
 
 A commit having changes only in `/ProjectB/*` path would be ignored. A commit having changes in the following paths wouldn't be ignored:
@@ -346,17 +441,19 @@ there is a rogue commit in history yielding a bad version. You can use either
 style below:
 
 ```yaml
-ignore:
-  sha: [e7bc24c0f34728a25c9187b8d0b041d935763e3a, 764e16321318f2fdb9cdeaa56d1156a1cba307d7]
+calculation:
+  ignore:
+    sha: [e7bc24c0f34728a25c9187b8d0b041d935763e3a, 764e16321318f2fdb9cdeaa56d1156a1cba307d7]
 ```
 
 or
 
 ```yaml
-ignore:
-  sha:
-    - e7bc24c0f34728a25c9187b8d0b041d935763e3a
-    - 764e16321318f2fdb9cdeaa56d1156a1cba307d7
+calculation:
+  ignore:
+    sha:
+      - e7bc24c0f34728a25c9187b8d0b041d935763e3a
+      - 764e16321318f2fdb9cdeaa56d1156a1cba307d7
 ```
 
 #### tags
@@ -368,10 +465,11 @@ use OR semantics, and `^` and `$` can be used to anchor a match. To require
 case-sensitive matching, prefix a pattern with `(?-i)`.
 
 ```yaml
-ignore:
-  tags:
-    - ^experimental-
-    - ^v0\.
+calculation:
+  ignore:
+    tags:
+      - ^experimental-
+      - ^v0\.
 ```
 
 Ignoring a tag does not ignore the commit it points to. The commit remains part
@@ -405,23 +503,25 @@ branch.
 A complete example:
 
 ```yaml
-branches:
-  unstable:
-    regex: ...
-    is-source-branch-for: ['main', 'develop', 'feature', 'hotfix', 'support']
+calculation:
+  branches:
+    unstable:
+      regex: ...
+      is-source-branch-for: ['main', 'develop', 'feature', 'hotfix', 'support']
 ```
 
 Without this configuration value you would have to do:
 
 ```yaml
-branches:
-  unstable:
-    regex:
-  feature:
-    source-branches: ['unstable', 'develop', 'feature', 'hotfix', 'support']
-  release:
-    source-branches: ['unstable', 'develop']
-  etc...
+calculation:
+  branches:
+    unstable:
+      regex:
+    feature:
+      source-branches: ['unstable', 'develop', 'feature', 'hotfix', 'support']
+    release:
+      source-branches: ['unstable', 'develop']
+    etc...
 ```
 
 ### major-version-bump-message
@@ -605,7 +705,12 @@ Configures GitVersion to update the build number or not when running on a build 
 
 ## Branch configuration
 
-Then we have branch specific configuration, which looks something like this:
+The following **v4 migration example** illustrates the change from regular-expression
+keys to named branch configurations. It uses the legacy flat layout and is retained
+only for that historical migration context; it is not a valid v7 configuration. For
+new v7 configuration, place branch calculation settings under `calculation.branches`
+and branch output settings under `output.branches`, as shown in the [v7 configuration
+layout](#v7-configuration-layout).
 
 :::{.alert .alert-info}
 **Note**
@@ -613,8 +718,7 @@ Then we have branch specific configuration, which looks something like this:
 v4 changed from using regexes for keys, to named configs
 :::
 
-If you have branch specific configuration upgrading to v4 will force you to
-upgrade.
+If you have branch-specific configuration, upgrading to v4 required this change.
 
 ```yaml
 workflow: 'GitHubFlow/v1'

--- a/docs/input/docs/usage/cli/arguments.md
+++ b/docs/input/docs/usage/cli/arguments.md
@@ -107,9 +107,35 @@ GitVersion [path]
                     GitVersion to not calculate your version as expected.
 ```
 
+## Configuration migration
+
+The POSIX parser exposes a `config migrate` subcommand for converting a v6
+configuration document to the v7 `calculation`/`output` layout:
+
+```shell
+gitversion config migrate
+gitversion config migrate --config GitVersion.yml --output GitVersion.v7.yml
+gitversion config migrate --config GitVersion.yml --in-place
+```
+
+It discovers a supported configuration filename when `--config` is omitted and
+writes YAML to stdout unless `--output` or `--in-place` is selected. `--output`
+will not replace an existing file without `--force`; it cannot be combined with
+`--in-place`. Replacing a file warns that comments are not preserved. The
+command does not require a Git repository and is unavailable when
+`GITVERSION_USE_V6_ARGUMENT_PARSER=true` selects the legacy parser.
+
 ## Override config
 
 `--override-config key=value` will override appropriate `key` from 'GitVersion.yml', 'GitVersion.yaml', '.GitVersion.yml' or '.GitVersion.yaml'.
+
+With the v7 default configuration layout, use a version-aware nested key. For
+example, `calculation.tag-prefix=custom`,
+`calculation.branches.main.increment=Patch`, and
+`output.branches.main.pre-release-weight=55000`. Flat v6 keys are rejected in
+v7 mode with their nested replacement. Set
+`GITVERSION_CONFIGURATION_VERSION=v6` only while validating a legacy file in
+v7.0.
 
 To specify multiple options add multiple `--override-config key=value` entries:
 `--override-config key1=value1 --override-config key2=value2`.


### PR DESCRIPTION
## Summary

- Documents the v7 `calculation` and `output` configuration layout and its v6 ownership mapping.
- Documents `gitversion config migrate`, versioned selectors, nested overrides, and the v7.0 to v8 lifecycle.
- Regenerates the configuration reference from its authored source and aligns migration, CLI, breaking-change, and managed-Git guidance.

## Validation

- `dotnet build ./src/GitVersion.slnx --no-restore`
- Targeted `GitVersion.App.Tests`: 277 passed
- `mdsnippets --write-header false`
- `BuildPrepare` and `GenerateSchemas` (no schema changes required)
- `git diff --check`
